### PR TITLE
Fix the docker-compose `command`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: load-balancer
     ports:
       - "3030:3030"
-    command: ./lb --backends "http://web1:80,http://web2:80,http://web3:80"
+    command: --backends "http://web1:80,http://web2:80,http://web3:80"
   web1:
     image: strm/helloworld-http
   web2:


### PR DESCRIPTION
The `command` is added to the `entrypoint`. In this case we only need to set the backends.